### PR TITLE
Manually Registering Events example fixed

### DIFF
--- a/events.md
+++ b/events.md
@@ -78,7 +78,7 @@ Typically, events should be registered via the `EventServiceProvider` `$listen` 
             [SendPodcastNotification::class, 'handle']
         );
 
-        Event::listen(function (PodcastProcessed $event) {
+        Event::listen(PodcastProcessed::class, function (PodcastProcessed $event) {
             //
         });
     }


### PR DESCRIPTION
Current docs has invalid facade reference:
```php
Event::listen(function (PodcastProcessed $event) {
    //
});
```

Working solution is listed below:
```php
Event::listen(PodcastProcessed::class, function (PodcastProcessed $event) {
    //
});
```